### PR TITLE
aliases stored in lowercase in java keystore

### DIFF
--- a/manifests/java.pp
+++ b/manifests/java.pp
@@ -89,7 +89,7 @@ define trusted_ca::java (
     cwd       => '/tmp',
     path      => $trusted_ca::path,
     logoutput => on_failure,
-    unless    => "echo '' | keytool -list -keystore ${java_keystore} | grep ${name}",
+    unless    => "echo '' | keytool -list -keystore ${java_keystore} | grep -i ${name}",
     require   => File["/tmp/${name}-trustedca"],
   }
 


### PR DESCRIPTION
#### Pull Request (PR) description
aliases stored in lowercase in java keystore. Used "grep -i" to fit this behaviour

@ekohl Unfortunately i forgot to add this change to get everything working. This fixes a failed puppet run because the unless statement doesn't work properly without "grep -i"