### PR TITLE
Drop EL6 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]
@@ -23,7 +22,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]


### PR DESCRIPTION
CentOS 6 is going EOL soon and the acceptance tests are failing on it.

Included in https://github.com/voxpupuli/puppet-trusted_ca/pull/28