### PR TITLE
Drop requirement for CA sources to use platform-specific suffix

### DIFF
--- a/manifests/ca.pp
+++ b/manifests/ca.pp
@@ -58,10 +58,6 @@ define trusted_ca::ca (
   }
 
   if $source {
-    if $source !~ Pattern["\\.${certfile_suffix}$"] {
-      fail("[Trusted_ca::Ca::${name}]: source must be a PEM encoded file with the ${certfile_suffix} extension")
-    }
-
     file { "${install_path}/${_name}":
       ensure => 'file',
       source => $source,

--- a/spec/defines/trusted_ca_ca_spec.rb
+++ b/spec/defines/trusted_ca_ca_spec.rb
@@ -9,12 +9,6 @@ describe 'trusted_ca::ca' do
         let(:pre_condition) { 'include trusted_ca' }
 
         context 'validations' do
-          context 'bad source' do
-            let(:params) { { source: 'foo' } }
-
-            it { is_expected.to compile.and_raise_error(%r{source must be a PEM encoded file}) }
-          end
-
           context 'bad content' do
             let(:params) { { content: '^' } }
 


### PR DESCRIPTION
#### Pull Request (PR) description

This appears to be an arbitrary requirement with no practical
applications. Having it present means having to use workarounds
to add a `trusted_ca::ca` using an existing file on disk which
does not match the designated suffix for the platorm, or to
write cross-platform code.

This commit drops the requirement entirely, so that any source
can be used to install a trusted ca regardless of the filename.
Since the file is copied to the destination location using the
correct platform-specific suffix, there should be no
backward-compatibility breaks.

#### This Pull Request (PR) fixes the following issues

Fixes #38
