### PR TITLE
Default to using the installed version

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,7 +1,7 @@
 # Class trusted_ca::params
 #
 class trusted_ca::params {
-  $certificates_version = 'latest'
+  $certificates_version = 'installed'
 
   case $facts['os']['family'] {
     'RedHat': {

--- a/spec/classes/trusted_ca_init_spec.rb
+++ b/spec/classes/trusted_ca_init_spec.rb
@@ -16,7 +16,7 @@ describe 'trusted_ca' do
                          end
 
           context 'default' do
-            it { is_expected.to contain_package(package_name).with(ensure: 'latest') }
+            it { is_expected.to contain_package(package_name).with(ensure: 'installed') }
           end
 
           context 'set version' do


### PR DESCRIPTION
Using ensure => latest on a package resource will trash yum/dnf's cache, which can create a large load. For users running Katello/Satellite it means their server will be under significant load.

Another use case it breaks is offline apply support. It's a bit of an edge case, but a user can download all resources (like RPMs), then apply an update using puppet apply. Using ensure latest will trash the caches, which breaks it. One such example is a self-registered Katello setup where the server consumes RPMs from itself. The installer will bring the services down (including the yum repository hosting), so a solution could be to download the RPM prior to updating.