### PR TITLE
Support EL 9: Avoid running update-ca-trust twice

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,7 +6,7 @@ class trusted_ca::params {
   case $facts['os']['family'] {
     'RedHat': {
       $path = ['/usr/bin', '/bin']
-      $update_command = 'update-ca-trust enable && update-ca-trust'
+      $update_command = 'update-ca-trust extract'
       $install_path = '/etc/pki/ca-trust/source/anchors'
       $certfile_suffix = 'crt'
       $certs_package = 'ca-certificates'

--- a/metadata.json
+++ b/metadata.json
@@ -16,14 +16,16 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {

--- a/spec/acceptance/certs_spec.rb
+++ b/spec/acceptance/certs_spec.rb
@@ -21,11 +21,11 @@ describe 'trusted_ca' do
       apply_manifest(pp, catch_failures: true)
     end
 
-    describe command("/usr/bin/curl https://#{fact('hostname')}.example.com:443") do
+    describe command("/usr/bin/curl https://#{fact('fqdn')}:443") do
       its(:exit_status) { is_expected.to eq 60 }
     end
 
-    describe command("cd /root && /usr/bin/java SSLPoke #{fact('hostname')}.example.com 443") do
+    describe command("cd /root && /usr/bin/java SSLPoke #{fact('fqdn')} 443") do
       its(:exit_status) { is_expected.to eq 1 }
     end
   end
@@ -34,7 +34,7 @@ describe 'trusted_ca' do
     it 'works idempotently with no errors' do
       pp = <<-EOS
       class { 'trusted_ca': }
-      trusted_ca::ca { 'test': source => '/etc/ssl-secure/test.crt' }
+      trusted_ca::ca { 'test': source => '/etc/ssl-secure/ca.crt' }
       EOS
 
       # Run it twice and test for idempotency
@@ -48,11 +48,11 @@ describe 'trusted_ca' do
 
     # https://github.com/rubocop/rubocop-rspec/issues/1231
     # rubocop:disable RSpec/RepeatedExampleGroupBody
-    describe command("/usr/bin/curl https://#{fact('hostname')}.example.com:443") do
+    describe command("/usr/bin/curl https://#{fact('fqdn')}:443") do
       its(:exit_status) { is_expected.to eq 0 }
     end
 
-    describe command("cd /root && /usr/bin/java SSLPoke #{fact('hostname')}.example.com 443") do
+    describe command("cd /root && /usr/bin/java SSLPoke #{fact('fqdn')} 443") do
       its(:exit_status) { is_expected.to eq 0 }
     end
     # rubocop:enable RSpec/RepeatedExampleGroupBody

--- a/spec/acceptance/helpers/gen_cert.sh
+++ b/spec/acceptance/helpers/gen_cert.sh
@@ -1,43 +1,40 @@
 #!/bin/sh
 
-OUTDIR=/etc/ssl-secure
+set -xe
 
-echodo()
-{
-    echo "${@}"
-    (${@})
-}
+OUTDIR=${OUTDIR:-/etc/ssl-secure}
+CN=$(hostname -f)
 
-C=US
-ST=Colorado
-L=Denver
-O=Example
-OU=Test
-CN=`hostname`
-
+cakey="${OUTDIR}/ca.key"
+cacert="${OUTDIR}/ca.crt"
 csr="${OUTDIR}/test.csr"
+csr_ext="${OUTDIR}/test.v3.ext"
 key="${OUTDIR}/test.key"
 cert="${OUTDIR}/test.crt"
 
-mkdir $OUTDIR
+mkdir "$OUTDIR"
+
+# Based on https://arminreiter.com/2022/01/create-your-own-certificate-authority-ca-using-openssl/
+
+# Create a CA
+openssl genrsa -aes256 -out "$cakey" -passout pass:ca-password 2048
+openssl req -x509 -new -passin pass:ca-password -passout pass:ca-password -key "$cakey" -sha256 -days 1826 -out "$cacert" -subj '/CN=Trusted CA acceptance tests Root CA'
 
 # Create the certificate signing request
-openssl req -new -passin pass:password -passout pass:password -out ${csr} <<EOF
-${C}
-${ST}
-${L}
-${O}
-${OU}
-${CN}
-$USER@${CN}
-.
-.
+openssl req -new -passin pass:password -nodes -out "$csr" -newkey rsa:2048 -keyout "$key" -subj "/CN=${CN}"
+
+# create a v3 ext file for SAN properties
+cat > "$csr_ext" << EOF
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = ${CN}
 EOF
 
-[ -f ${csr} ] && echodo openssl req -text -noout -in ${csr}
-
-# Create the Key
-openssl rsa -in privkey.pem -passin pass:password -passout pass:password -out ${key}
+# Inspect CSR
+openssl req -text -noout -in "$csr"
 
 # Create the Certificate
-openssl x509 -in ${csr} -out ${cert} -req -signkey ${key} -days 1000
+openssl x509 -req -passin pass:ca-password -in "$csr" -CA "$cacert" -CAkey "$cakey" -CAcreateserial -out "$cert" -days 730 -sha256 -extfile "$csr_ext"


### PR DESCRIPTION
On both EL 7 & EL 8 the argument is ignored, so the command is effectively running twice.

On EL 9 there is argument parsing. There is a difference how the enable argument is handled. In `ca-certificates-0:2024.2.69_v8.0.303-91.3.el9` it raises an error while [release 91.4 changes](https://gitlab.com/redhat/centos-stream/rpms/ca-certificates/-/commit/e42c2ba50ab725a76af2255b4f121d8e896ec92b) it to a a deprecation warning that users should use extract. Extract is also the behavior when no argument is given.

This simplifies the command to just plain update-ca-trust.

After that we can formally support EL 9.