### PR TITLE
Support Debian 11 & 12 + Ubuntu 22.04 & 24.04

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -46,13 +46,17 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "18.04",
-        "20.04"
+        "20.04",
+        "22.04",
+        "24.04"
       ]
     },
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "10"
+        "10",
+        "11",
+        "12"
       ]
     }
   ],


### PR DESCRIPTION
This is mainly to get CI running for Debian again because it doesn't run for EOL Debian 10.