### PR TITLE
Fix validate_cmd command in java.pp

### DIFF
--- a/manifests/java.pp
+++ b/manifests/java.pp
@@ -51,7 +51,7 @@ define trusted_ca::java (
     mode         => '0644',
     owner        => 'root',
     group        => 'root',
-    validate_cmd => '/usr/bin/openssl x509 -in %s -noout',
+    validate_cmd => '/usr/bin/openssl x509 -in % -noout',
     notify       => Exec["import ${filename} to jks ${java_keystore}"],
   }
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
PR fixes wrong validate_cmd command in java.pp file in tag v5.1.0

#### This Pull Request (PR) fixes the following issues
The validate_cmd used a wrong validate_replacement string.
It should be % not %s.
With %s all files to check via validate_cmd ends with the char s. 
So, the validate_cmd will always fail because the filename doesn't match
