### PR TITLE
fix syntax error in trusted_ca::java exec resource #76

### DIFF
--- a/manifests/java.pp
+++ b/manifests/java.pp
@@ -61,6 +61,6 @@ define trusted_ca::java (
     path      => $trusted_ca::path,
     logoutput => on_failure,
     unless    => "echo '' | keytool -list -keystore ${java_keystore} | grep -i ${name}",
-    require   => File["/tmp/${name}-trustedca"],
+    require   => File[$filename],
   }
 }


### PR DESCRIPTION

#### Pull Request (PR) description
Fix syntax error in trusted_ca::java exec resource by changing the value of `require` attribute to `$filename`.

#### This Pull Request (PR) fixes the following issues
Fixes #76
