### PR TITLE
Fix validate_cmd failing when file resouce is absent

### DIFF
--- a/manifests/java.pp
+++ b/manifests/java.pp
@@ -51,7 +51,6 @@ define trusted_ca::java (
     mode         => '0644',
     owner        => 'root',
     group        => 'root',
-    #validate_cmd => '/usr/bin/openssl x509 -in % -noout',
     notify       => Exec["validate ${filename} contents"],
   }
 

--- a/manifests/java.pp
+++ b/manifests/java.pp
@@ -51,7 +51,17 @@ define trusted_ca::java (
     mode         => '0644',
     owner        => 'root',
     group        => 'root',
-    validate_cmd => '/usr/bin/openssl x509 -in % -noout',
+    #validate_cmd => '/usr/bin/openssl x509 -in % -noout',
+    notify       => Exec["validate ${filename} contents"],
+  }
+
+  exec { "validate ${filename} contents":
+    command      => "/usr/bin/openssl x509 -in ${filename} -noout",
+    cwd          => '/tmp',
+    path         => $trusted_ca::path,
+    logoutput    => on_failure,
+    require      => File[$filename],
+    refreshonly  => true,
     notify       => Exec["import ${filename} to jks ${java_keystore}"],
   }
 


### PR DESCRIPTION
#### Pull Request (PR) description
Instead of relying on file attribute `validate_cmd` I have added a secondary exec to validate the intermediate file. 
This added exec is triggered by the file resource and in turn triggers the `keytool import` exec. 
This method allows for the case where the intermediate file does not yet exist.

This is a more clunky solution, but it seems to work in my environment.
I'm not sure how to write an rspec test for this.  



#### This Pull Request (PR) fixes the following issues
Fixes #76
